### PR TITLE
Fix for undefined window when using o3dgc.js in a web worker.

### DIFF
--- a/server/o3dgc/js/o3dgc.js
+++ b/server/o3dgc/js/o3dgc.js
@@ -179,15 +179,13 @@ var o3dgc = (function () {
         return pos;
     }
     // Timer class
-    if (typeof window.performance === 'undefined') {
-        window.performance = {};
-    }
-    if (!window.performance.now) {
+    var windowPerformance = typeof window !== 'undefined' && typeof window.performance !== 'undefined' ? window.performance : {};
+    if (!windowPerformance.now) {
         local.nowOffset = Date.now();
         if (performance.timing && performance.timing.navigationStart) {
             local.nowOffset = performance.timing.navigationStart;
         }
-        window.performance.now = function now() {
+        windowPerformance.now = function now() {
             return Date.now() - local.nowOffset;
         };
     }
@@ -196,10 +194,10 @@ var o3dgc = (function () {
         this.m_end = 0;
     };
     module.Timer.prototype.Tic = function () {
-        this.m_start = window.performance.now();
+        this.m_start = windowPerformance.now();
     };
     module.Timer.prototype.Toc = function () {
-        this.m_end = window.performance.now();
+        this.m_end = windowPerformance.now();
     };
     module.Timer.prototype.GetElapsedTime = function () {
         return this.m_end - this.m_start;


### PR DESCRIPTION
Fixes an error when `window` is `undefined` when using o3dgc.js from a web worker.

CC @kmammou @pjcozzi