### PR TITLE
Change WIN32 to _WIN32

### DIFF
--- a/server/o3dgc/src/o3dgc_common_lib/inc/o3dgcTimer.h
+++ b/server/o3dgc/src/o3dgc_common_lib/inc/o3dgcTimer.h
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 #include "o3dgcCommon.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #elif __MACH__
 #include <mach/clock.h>
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
 namespace o3dgc
 {
-#ifdef WIN32
+#ifdef _WIN32
     class Timer
     {
     public: 


### PR DESCRIPTION
o3dgcTimer.h uses the WIN32 preprocessor symbol, but this is not a standard symbol defined by MSVC.  The proper symbol to use is _WIN32.  This simplifies build configuration.