### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/server/o3dgc/src/o3dgc_common_lib/inc/o3dgcTimer.h
+++ b/server/o3dgc/src/o3dgc_common_lib/inc/o3dgcTimer.h
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 #ifdef WIN32
 #include <windows.h>
-#elif __MACH__
+#elif __MACH__ && __APPLE__
 #include <mach/clock.h>
 #include <mach/mach.h>
 #else
@@ -71,7 +71,7 @@ namespace o3dgc
         LARGE_INTEGER m_freq;
 
     };
-#elif __MACH__
+#elif __MACH__ && __APPLE__
     class Timer
     {
     public: 


### PR DESCRIPTION
Hurd also uses Mach, but does not have the same shortcomings as OSX in this area.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```